### PR TITLE
Add collaboration guide and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+venv/
+__pycache__/
+*.pyc
+.DS_Store

--- a/CODEGPTV6_INSTRUCTIONS.md
+++ b/CODEGPTV6_INSTRUCTIONS.md
@@ -1,0 +1,34 @@
+# CODEGPTV6 Expert Collaboration Guide
+
+This document describes the conversation modes available when collaborating with the CODEGPTV6 assistant. Each category defines how experts will interact and the type of feedback provided during a project discussion.
+
+## Overview
+
+Upon providing project details, select a category to shape the discussion. Experts will share insights, suggest improvements, and request clarification according to the chosen mode. After each interaction segment, you can either continue the conversation or request to see code examples.
+
+## Categories
+
+1. **Silent Consultation** – Experts confer among themselves without addressing you directly. They develop ideas collaboratively and conclude with a list of filenames.
+2. **Expert Q&A** – Experts take turns asking you questions about your project. Provide answers until you request the code prompt.
+3. **Iterative Feedback** – Experts offer initial suggestions, then adjust their advice based on your responses.
+4. **Implementation Chat** – Experts discuss technical details, share sample snippets, and brainstorm solutions to specific challenges.
+5. **Testing & Debugging** – Focus on test scenarios, troubleshooting steps, and best practices for validating code.
+6. **Refactoring & Optimization** – Guidance on improving performance, readability, and structure of your codebase.
+7. **Error and Exception Handling** – Strategies for managing errors gracefully with example patterns.
+8. **Integration & Interoperability** – Advice on connecting your project with external services, APIs, and protocols.
+9. **Data Storage & Persistence** – Recommendations for choosing databases, file storage, and caching mechanisms.
+10. **Security & Authentication** – Discuss secure coding practices, encryption, and authorization techniques.
+11. **Version Control & Collaboration** – Tips on using Git and teamwork tools effectively.
+12. **Documentation & Comments** – Best practices for writing clear documentation and helpful code comments.
+
+## Conversation Flow
+
+At the end of each conversation segment, the assistant will provide options:
+
+```
+Options: [continue] - continue the experts' chat.
+         [code prompt] - unveil the project code.
+```
+
+Choose `continue` to keep the discussion going or `code prompt` when ready to view code examples.
+


### PR DESCRIPTION
## Summary
- add CODEGPTV6 collaboration guide describing expert categories and flow
- create `.gitignore` to exclude `venv` and compiled files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862ecdb839c8323bd1fe816b4f42e9e