### PR TITLE
Fix docker-compose paths and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains a minimal AI trading stack with a FastAPI backend and a
 ## Project Layout
 - **backend/** – FastAPI application and trading logic
 - **frontend/** – Next.js client
-- **docker/** – Dockerfiles and `docker-compose.yml`
+- **docker/** – Dockerfiles
 - **scripts/** – Deployment and helper scripts
 - `.env` – environment variables loaded by the backend
 
@@ -14,7 +14,7 @@ This repository contains a minimal AI trading stack with a FastAPI backend and a
 2. Build and run the stack:
 
 ```bash
-cd docker && docker-compose up --build -d
+docker-compose up --build -d
 ```
 
 The API will be available on `http://localhost:8000` and the frontend on `http://localhost:3000`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   zeus-api:
     build:
       context: ./backend
-      dockerfile: backend.Dockerfile
+      dockerfile: Dockerfile
     container_name: zeus_api
     ports:
       - "8000:8000"
@@ -18,7 +18,7 @@ services:
   zeus-frontend:
     build:
       context: ./frontend
-      dockerfile: frontend.Dockerfile
+      dockerfile: Dockerfile
     container_name: zeus_frontend
     ports:
       - "3000:3000"


### PR DESCRIPTION
## Summary
- correct Dockerfile names in docker-compose.yml
- update README instructions for running docker-compose

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6863b742eaa483239aabb770b2e7a57c